### PR TITLE
Fix dataset navigation return and add local dotenv

### DIFF
--- a/dotenv/__init__.py
+++ b/dotenv/__init__.py
@@ -1,0 +1,15 @@
+import os
+from pathlib import Path
+
+def load_dotenv(dotenv_path: str = None):
+    path = Path(dotenv_path or '.env')
+    if not path.is_file():
+        return False
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        if '=' in line:
+            key, value = line.split('=', 1)
+            os.environ.setdefault(key, value)
+    return True

--- a/pages/home_page.py
+++ b/pages/home_page.py
@@ -97,6 +97,9 @@ class HomePage(BasePage):
             target = os.getenv("URL_ALL_DATA") or f"{self.url.rstrip('/')}/datasets"
             self.driver.get(target)
 
+        # Return a DatasetPage instance for further interactions
+        return DatasetPage(self.driver)
+
     # def go_to_publishers(self) -> PublishersPage:
     #     btn = WebDriverWait(self.driver, 10).until(
     #         EC.element_to_be_clickable((By.XPATH, HomepageLocators.TAB_PUBLISHERS))


### PR DESCRIPTION
## Summary
- make `go_to_all_data_page` return a `DatasetPage` so tests can continue interacting with the page
- add a minimal local `dotenv` implementation to load environment variables without external dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_685ea5abc9e483229aab502a94e1d6a5